### PR TITLE
Adds Property 'dsf.location' to Override the Default Location

### DIFF
--- a/dsf-bpe-process-feasibility/pom.xml
+++ b/dsf-bpe-process-feasibility/pom.xml
@@ -13,6 +13,7 @@
 	
 	<properties>
 		<main.basedir>${project.basedir}/..</main.basedir>
+		<dsf.location>../../highmed-dsf</dsf.location>
 	</properties>
 
 	<dependencies>
@@ -68,7 +69,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -85,7 +86,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -102,7 +103,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -119,7 +120,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -136,7 +137,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 						</executions>
@@ -147,35 +148,35 @@
 						<configuration>
 							<filesets>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>

--- a/dsf-bpe-process-local-services/pom.xml
+++ b/dsf-bpe-process-local-services/pom.xml
@@ -14,6 +14,7 @@
 	
 	<properties>
 		<main.basedir>${project.basedir}/..</main.basedir>
+		<dsf.location>../../highmed-dsf</dsf.location>
 	</properties>
 
 	<dependencies>
@@ -69,7 +70,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -86,7 +87,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -103,7 +104,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -120,7 +121,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -137,7 +138,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 						</executions>
@@ -148,35 +149,35 @@
 						<configuration>
 							<filesets>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>

--- a/dsf-bpe-process-ping/pom.xml
+++ b/dsf-bpe-process-ping/pom.xml
@@ -12,6 +12,7 @@
 	
 	<properties>
 		<main.basedir>${project.basedir}/..</main.basedir>
+		<dsf.location>../../highmed-dsf</dsf.location>
 	</properties>
 
 	<dependencies>
@@ -62,7 +63,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -79,7 +80,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -96,7 +97,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -113,7 +114,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -130,7 +131,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 						</executions>
@@ -141,35 +142,35 @@
 						<configuration>
 							<filesets>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>

--- a/dsf-bpe-process-update-allow-list/pom.xml
+++ b/dsf-bpe-process-update-allow-list/pom.xml
@@ -12,6 +12,7 @@
 	
 	<properties>
 		<main.basedir>${project.basedir}/..</main.basedir>
+		<dsf.location>../../highmed-dsf</dsf.location>
 	</properties>
 
 	<dependencies>
@@ -62,7 +63,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -79,7 +80,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -96,7 +97,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -113,7 +114,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -130,7 +131,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 						</executions>
@@ -141,35 +142,35 @@
 						<configuration>
 							<filesets>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>

--- a/dsf-bpe-process-update-resources/pom.xml
+++ b/dsf-bpe-process-update-resources/pom.xml
@@ -12,6 +12,7 @@
 	
 	<properties>
 		<main.basedir>${project.basedir}/..</main.basedir>
+		<dsf.location>../../highmed-dsf</dsf.location>
 	</properties>
 
 	<dependencies>
@@ -62,7 +63,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -79,7 +80,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -96,7 +97,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -113,7 +114,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 							<execution>
@@ -130,7 +131,7 @@
 											<version>${project.version}</version>
 										</artifactItem>
 									</artifactItems>
-									<outputDirectory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</outputDirectory>
+									<outputDirectory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</outputDirectory>
 								</configuration>
 							</execution>
 						</executions>
@@ -141,35 +142,35 @@
 						<configuration>
 							<filesets>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic1/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic2/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/medic3/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>
 									<followSymlinks>false</followSymlinks>
 								</fileset>
 								<fileset>
-									<directory>../../highmed-dsf/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</directory>
+									<directory>${dsf.location}/dsf-docker-test-setup-3medic-ttp/ttp/bpe/app/process</directory>
 									<includes>
 										<include>${project.artifactId}-${project.version}.jar</include>
 									</includes>


### PR DESCRIPTION
Building the HiGHmed processes project for example via
  
`mvn clean install -Pcopy-to-highmed-dsf-process -Ddsf.location=../../highmed-dsf-alt`  

allows for the highmed-dsf to be located in a folder called `highmed-dsf-alt` next to the highmed-processes project.

closes #15